### PR TITLE
chore: removing kms key for testing purposes

### DIFF
--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -36,17 +36,12 @@ const scanStatusLambaArn = backend.scanStatus.resources.lambda.functionArn;
 const instanceFindingsLambdaArn = backend.instanceFindings.resources.lambda.functionArn;
 
 
+
 const customResourceStack = backend.createStack("AwsIceCustomResources");
 
 
-const kmsKey = new kms.Key(customResourceStack, "ScapS3KMS", {
-  enableKeyRotation: true,
-});
-
 const scapScanResultsBucket = new s3.Bucket(customResourceStack, "SCAPScanResultsBucket", {
   bucketName: "my-scap-scan-results-bucket-2024-11-01", 
-  encryption: s3.BucketEncryption.KMS,
-  encryptionKey: kmsKey,
   publicReadAccess: false,
   blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
 });
@@ -304,6 +299,7 @@ const scapScanSSMDocument = new ssm.CfnDocument(customResourceStack, 'SCAPScanDo
   },
   documentType: 'Command',
 });
+
 
 
 


### PR DESCRIPTION
removing kms key for testing purposes. Will add later in a security hardening story 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the encryption configuration for the SCAPScanResultsBucket to use Amazon S3-managed keys rather than KMS-managed keys, simplifying encryption management. 

- **Chores**
	- Removed KMS key creation from the resource stack, streamlining resource management and reducing complexity related to key rotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->